### PR TITLE
[NoTicket] Avatar Creator Reload Fixes

### DIFF
--- a/Assets/WebGLTemplates/RPMTemplate/TemplateData/ReadyPlayerMeFrame.js
+++ b/Assets/WebGLTemplates/RPMTemplate/TemplateData/ReadyPlayerMeFrame.js
@@ -41,7 +41,7 @@ function setupRpmFrame(subdomain) {
 
         // Get avatar GLB URL
         if (json.eventName === "v1.avatar.exported") {
-            rpmContainer.style.display = "none";
+            hideRpm();
             // Send message to a Gameobject in the current scene
             unityGame.SendMessage(
                 "WebAvatarLoader", // Target GameObject name
@@ -72,4 +72,5 @@ function showRpm() {
 
 function hideRpm() {
     rpmContainer.style.display = "none";
+    rpmFrame.src = rpmFrame.src;
 }

--- a/Assets/WebGlHelper/WebHelper.jslib
+++ b/Assets/WebGlHelper/WebHelper.jslib
@@ -1,13 +1,11 @@
 mergeInto(LibraryManager.library, {
 
     ShowReadyPlayerMeFrame: function () {
-        var rpmContainer = document.getElementById("rpm-container");
-        rpmContainer.style.display = "block";
+        showRpm();
     },
   
     HideReadyPlayerMeFrame: function () {
-        var rpmContainer = document.getElementById("rpm-container");
-        rpmContainer.style.display = "none";
+        hideRpm();
     },
         
     SetupRpm: function (partner){


### PR DESCRIPTION
## Changes

#### Updated

- ReadyPlayerMeFrame.js 
> - Fixed bug that prevented the RPM Avatar Creator from being launched multiple times by forcing the iframe to reload when hidden (in a cross-browser stable way) 
> - Replaced 'none' assignment with call to hideRPM to enforce reload in all cases

- WebHelper.jslib 
> - Replaced 'block' and 'none' assignments with calls to the functions 'showRpm' and 'hideRpm' to reduce duplication, enforce the reload fix in RPMFrame, and remove the need to recompile the lib when testing functionality changes

<!-- Testability -->

## ISSUE:
- Press "Create Avatar"
- Either create/select an avatar or just press Hide to return to the previous page
- Press "Create Avatar" again, the creator will open again but it will go directly to a "Loading" screen that never resolves

## How to Test
- Same as above, but on the second attempt the avatar creator will load instead of stalling

